### PR TITLE
Avoid ssize_t

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ TESTS = \
 	tests/decode-zero.sh \
 	tests/encode.sh \
 	tests/encode-b58c.sh \
+	tests/encode-b58c-high.sh \
 	tests/encode-fail.sh \
 	tests/encode-small.sh
 SH_LOG_COMPILER = /bin/sh

--- a/base58.c
+++ b/base58.c
@@ -15,7 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/types.h>
 
 #include "libbase58.h"
 
@@ -146,7 +145,7 @@ bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz)
 {
 	const uint8_t *bin = data;
 	int carry;
-	ssize_t i, j, high, zcount = 0;
+	size_t i, j, high, zcount = 0;
 	size_t size;
 	
 	while (zcount < binsz && !bin[zcount])
@@ -163,6 +162,10 @@ bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz)
 			carry += 256 * buf[j];
 			buf[j] = carry % 58;
 			carry /= 58;
+			if (!j) {
+				// Otherwise j wraps to maxint which is > high
+				break;
+			}
 		}
 	}
 	

--- a/tests/encode-b58c-high.sh
+++ b/tests/encode-b58c-high.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+b58=$(echo 'ff5a1fc5dd9e6f03819fca94a2d89669469667f9a0' | xxd -r -p | base58 -c)
+test x$b58 = x2mkQLxaN3Y4CwN5E9rdMWNgsXX7VS6UnfeT


### PR DESCRIPTION
`ssize_t` is POSIX-specific, so just avoid `j` from falling negative instead.