### PR TITLE
Remove potential buffer overrun in base58.c

### DIFF
--- a/base58.c
+++ b/base58.c
@@ -51,8 +51,13 @@ bool b58tobin(void *bin, size_t *binszp, const char *b58, size_t b58sz)
 	unsigned zerocount = 0;
 	
 	if (!b58sz)
-		b58sz = strlen(b58);
-	
+		// Limit to 36 characters (including terminating NULL)
+		b58sz = strnlen(b58, 36);
+
+	// Length must be 26-35 characters
+	if (b58sz < 26 || b58sz > 35)
+		return false;
+
 	for (i = 0; i < outisz; ++i) {
 		outi[i] = 0;
 	}


### PR DESCRIPTION
The strlen() function doesn't stop until it finds a 0, which means it has the potential to read quite far out of bounds, so replacing it with strnlen() mitigates this.

I also added a Bitcoin address size check (26 to 35 characters is my understanding) immediately after (returning false if it's too short or too long), which prevents wasting CPU resources on an address (that will fail anyway due to not being the right size).